### PR TITLE
Set default layout for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Here's the template, copy it from here into a simple text editor of your choice.
 
 ```
 ---
-layout: example #ignore layout! :)
 title: #add title#
 author: #add author#
 overview:

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,14 @@ collections:
         permalink: /examples/:name
     components:
         output: false
+
+defaults:
+  - scope:
+      path: ""
+      type: "examples"
+    values:
+      layout: "example"
+
 plugins:
 - jekyll-last-modified-at # doesn't work with collections
 - jekyll-seo-tag

--- a/_examples/10-principles-of-codecademycom.md
+++ b/_examples/10-principles-of-codecademycom.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 10 Principles of Codecademy
 author: Codecademy.com
 overview: Codecademy spent three months developing this set of principles. The source contains additional contextual screenshots and videos.

--- a/_examples/10-usability-heuristics-for-user-interface-design.md
+++ b/_examples/10-usability-heuristics-for-user-interface-design.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: 10 Usability Heuristics for User Interface Design
 author: Jakob Nielsen
 overview: |
-    
+
 link: https://www.nngroup.com/articles/ten-usability-heuristics/
 principles:
 - principle: Visibility of system status

--- a/_examples/20-guiding-principles-for-experience-design.md
+++ b/_examples/20-guiding-principles-for-experience-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 20 Guiding Principles for Experience Design
 author: Whitney Hess
 overview: |
@@ -7,83 +6,83 @@ overview: |
 link: http://whitneyhess.com/blog/2009/11/23/so-you-wanna-be-a-user-experience-designer-step-2-guiding-principles/
 principles:
 - principle: Stay out of people’s way
-  summary: | 
+  summary: |
     When someone is trying to get something done, they’re on a mission. Don’t interrupt them unnecessarily, don’t set up obstacles for them to overcome, just pave the road for an easy ride. Your designs should have intentional and obvious paths, and should allow people to complete tasks quickly and freely.
 
 - principle: Present few choices
-  summary: | 
+  summary: |
     The more choices a person is presented with, the harder it is for them to choose. This is what Barry Schwartz calls The Paradox of Choice. Remove the “nice to haves” and focus instead of the necessary alternatives a person needs to make in order to greatly impact the outcome.
 
 - principle: Limit distractions
-  summary: | 
+  summary: |
     It’s a myth that people can multitask. Short of chewing gum while walking, people can’t actually do two things simultaneously; they end up giving less attention to both tasks and the quality of the interaction suffers. An effective design allows people to focus on the task at hand without having their attention diverted to less critical tasks. Design for tasks to be carried out consecutively instead of concurrently in order to keep people in the moment.
 
 - principle: Group related objects near each other
-  summary: | 
+  summary: |
     Layout is a key ingredient to creating meaningful and useful experiences. As a person scans a page for information, they form an understanding about what you can do for them and what they can do for themselves using your services. To aid in that learning process, and to motivate interaction, don’t force people to jump back and forth around disparate areas in order to carry out a single task. The design should be thoughtfully organized with related features and content areas appropriately chunked, and…
 
 - principle: Create a visual hierarchy that matches the user’s needs
-  summary: | 
+  summary: |
     …by giving the most crucial elements the greatest prominence. “Visual hierarchy” is a combination of several dimensions to aid in the processing of information, such as color, size, position, contrast, shape, proximity to like items, etc. Not only must a page be well organized so that it’s easy to scan, but the prioritization of information and functionality ought to mimic real world usage scenarios. Don’t make the most commonly used items the furthest out of reach.
 
 - principle: Provide strong information scent
-  summary: | 
+  summary: |
     People don’t like to guess. When they click around your site or product, they aren’t doing so haphazardly; they’re trying to follow their nose. If what they find when they get there isn’t close to what they predicted, chances are they’re going to give up and go elsewhere. Make sure that you use clear language and properly set expectations so that you don’t lead people down the wrong path.
 
 - principle: Provide signposts and cues
-  summary: | 
+  summary: |
     Never let people get lost. Signposts are one of the most important elements of any experience, especially one on the web where there are an infinite number of paths leading in all directions. The design should keep people aware of where they are within the overall experience at all times in a consistent and clear fashion. If you show them where they came from and where they’re going, they’ll have the confidence to sit back and relax and enjoy the ride.
 
 - principle: Provide context
-  summary: | 
+  summary: |
     Context sets the stage for a successful delivery. By communicating how everything interrelates, people are much more likely to understand the importance of what they’re looking at. Ensure that the design is self-contained and doesn’t break people out of the experience except for when it’s entirely necessary to communicate purpose.
 
 - principle: Avoid jargon
-  summary: | 
+  summary: |
     Remember that the experience is about them (the customer), not you (the business). Like going to a foreign country and expecting the lady behind the counter to understand English, it’s just as rude to talk to your visitors using lingo that’s internal to your company or worse, expressions you made up to seem witty. Be clear, kind and use widely understood terminology.
 
 - principle: Make things efficient
-  summary: | 
+  summary: |
     A primary goal of experience design is to make things efficient for the human before making things efficient for the computer. Efficiency allows for productivity and reduced effort, and a streamlined design allows more to get done in the same amount of time. Creating efficiency demonstrates a great deal of respect for your customers, and they’ll be sure to notice.
 
 - principle: Use appropriate defaults
-  summary: | 
+  summary: |
     Providing preselected or predetermined options is one of the ways to minimize decisions and increase efficiency. But choose wisely: if you assign the defaults to the wrong options (meaning that the majority of people are forced to change the selection), you’ll end up creating more stress and processing time.
 
 - principle: Use constraints appropriately
-  summary: | 
+  summary: |
     Preventing error is a lot better than just recovering from it. If you know ahead of time that there are certain restrictions on data inputs or potential dead ends, stop people from going down the wrong road. By proactively indicating what is not possible, you help to establish what is possible, and guide people to successful interactions. But make sure the constraints are worthwhile — don’t be overly cautious or limiting when it’s just to make things easier for the machine.
 
 - principle: Make actions reversible
-  summary: | 
+  summary: |
     There is no such thing as a perfect design. No one and nothing can prevent all errors, so you’re going to need a contingency plan. Ensure that if people make mistakes (either because they misunderstood the directions or mistyped or were misled by you), they are able to easily fix them. Undo is probably the most powerful control you can give a person — if only we had an undo button in life.
 
 - principle: Reduce latency
-  summary: | 
+  summary: |
     No one likes to wait. Lines suck. So do delays in an interface. Do whatever you can to respond to people’s requests quickly or else they’ll feel like you aren’t really listening. And if they really have to wait…
 
 - principle: Provide feedback
-  summary: | 
+  summary: |
     …tell them why they’re waiting. Tell them that you’re working. Tell them you heard them and offer the next step along their path. Design is not a monologue, it’s a conversation.
 
 - principle: Use emotion
-  summary: | 
+  summary: |
     Ease of use isn’t the only measure of a positive user experience; pleasurably is just as important. Something can be dead simple, but if it’s outrageously boring or cold it can feel harder to get through. Designs should have flourishes of warmth, kindness, whimsy, richness, seduction, wit — anything that incites passion and makes the person feel engaged and energized.
 
 - principle: Less is more
-  summary: | 
+  summary: |
     This isn’t necessarily about minimalism, but it is important to make sure that everything in the design has a purpose. Some things are purely functional; other things are purely aesthetic. But if they aren’t adding to the overall positivity of the experience, then take it out. Reduce the design to the necessary fundamentals and people will find it much easier to draw themselves in the white space.
 
 - principle: Be consistent
-  summary: | 
+  summary: |
     Navigational mechanisms, organizational structure and metaphors used throughout the design must be predictable and reliable. When things don’t match up between multiple areas, the experience can feel disjointed, confusing and uncomfortable. People will start to question whether they’re misunderstanding the intended meaning or if they missed a key cue. Consistency implies stability, and people always want to feel like they’re in good hands.
 
 - principle: Make a good first impression
-  summary: | 
+  summary: |
     You don’t get a second chance! Designing a digital experience is really no different than establishing a set of rules for how to conduct yourself in a relationship. You want to make people feel comfortable when you first meet them, you want to set clear expectations about what you can and can’t offer, you want to ease them into the process, you want to be attractive and appealing and strong and sensible. Ultimately you want to ensure that they can see themselves with you for a long time.
 
 - principle: Be credible and trustworthy
-  summary: | 
+  summary: |
     It’s hard to tell who you can trust these days, so the only way to gain the confidence of your customers is to earn it — do what you say you’re going to do, don’t over promise and under deliver, don’t sell someone out to fulfill a business objective. If you set people’s expectations appropriately and follow through in a timely matter, people will give you considerably more leeway than if they’re just waiting for you to screw them over.
 
 

--- a/_examples/37-signals-principles.md
+++ b/_examples/37-signals-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 37 Signals Principles
 author: 37 Signals
 overview:

--- a/_examples/5-guiding-principles-for-experience-design.md
+++ b/_examples/5-guiding-principles-for-experience-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 5 Guiding Principles for Experience Designers
 author: Whitney Hess
 overview: |

--- a/_examples/5-principles-for-the-wearable-revolution.md
+++ b/_examples/5-principles-for-the-wearable-revolution.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 5 Principles for the wearable revolution
 author: Fjord
 overview: |

--- a/_examples/5-rules-for-incorporation-ai-tech-into-design.md
+++ b/_examples/5-rules-for-incorporation-ai-tech-into-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 5 rules for incorporating AI tech into design
 author: Tom Castle
 overview: #Work in progress

--- a/_examples/7-principles-of-rich-web-applications.md
+++ b/_examples/7-principles-of-rich-web-applications.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 7 Principles of Rich Web Applications
 author: Guillermo Rauch
 overview: |

--- a/_examples/8-design-principles-for-organizational-transformation.md
+++ b/_examples/8-design-principles-for-organizational-transformation.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: 8 Design Principles for Organizational Transformation
 author: Xplane
 overview: |

--- a/_examples/8-fundamentals-for-userfriendly-product-development.md
+++ b/_examples/8-fundamentals-for-userfriendly-product-development.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: 8 fundamentals for user friendly product development
 author: Devhouse Spindle / Luuk Hartsema
 overview:
-link: 
+link:
 principles:
 - principle: Consistency
   summary: Embrace patterns and recognize that our usability is greatly improved when similar parts are expressed in similar ways. Interfaces that are consistent are more predictable, which means that they are easier to learn. Learnable interfaces feel more usable since less friction is involved.

--- a/_examples/about-foodspotting.md
+++ b/_examples/about-foodspotting.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: About Foodspotting
 author: Foodspotting
 overview: |

--- a/_examples/airbnb-design-principles.md
+++ b/_examples/airbnb-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Airbnb's Design Principles
 link : https://airbnb.design/the-way-we-build/
 author: Airbnb

--- a/_examples/amazon-s-leadership-principles.md
+++ b/_examples/amazon-s-leadership-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Amazon's Leadership Principles
 author: Amazon
 source: https://www.amazon.jobs/principles

--- a/_examples/amp-design-principles.md
+++ b/_examples/amp-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: AMP Design Principles
 author: AMP Project
 overview: |

--- a/_examples/android-design-principles.md
+++ b/_examples/android-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Android Design Principles
 author: Android Developers
 overview: |

--- a/_examples/android-wear-creative-vision.md
+++ b/_examples/android-wear-creative-vision.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Design Principles of Android Wear
 author: Android Developers
 overview:

--- a/_examples/ant-design.md
+++ b/_examples/ant-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Ant Design
 author: Alibaba
 overview: Ant Design is created for improving the experience of users, designers and developers in enterprise internal desktop applications.

--- a/_examples/asana-design-principles.md
+++ b/_examples/asana-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Asana's Design Principles
 author: Asana
 overview:

--- a/_examples/audible-people-principles.md
+++ b/_examples/audible-people-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example 
 title: Audible's People Principles
 author: Audible
 overview:

--- a/_examples/australia-designgov-principles.md
+++ b/_examples/australia-designgov-principles.md
@@ -1,10 +1,9 @@
 ---
-layout: example
 title: Australia DesignGov Principles
 author: DesignGov Australia
 overview: |
 
-link: 
+link:
 principles:
 - principle: Connected, Customer and Community Centric
 - principle: Courageous

--- a/_examples/basic-principles-of-nui-design.md
+++ b/_examples/basic-principles-of-nui-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Basic Principles of NUI Design
 author: Dan Saffer
 overview:

--- a/_examples/bbc-design-philosophy.md
+++ b/_examples/bbc-design-philosophy.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: BBC Design Philosophy
 author: BBC
 overview:

--- a/_examples/clean_forest_consulting.md
+++ b/_examples/clean_forest_consulting.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Clean Forest Consulting
 author: Noam Eppel
 overview:

--- a/_examples/co-op-design-principles.md
+++ b/_examples/co-op-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles
 author: Co-op
 overview: |

--- a/_examples/d-mindsets.md
+++ b/_examples/d-mindsets.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: D.Mindsets
 author: d.school
 overview: |

--- a/_examples/design-in-the-era-of-the-algorithm.md
+++ b/_examples/design-in-the-era-of-the-algorithm.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Design in the Era of the Algorithm
 author: Josh Clark
 overview: Here are ten design principles for conceiving, designing, and managing data-driven products.

--- a/_examples/design-manifesto.md
+++ b/_examples/design-manifesto.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Manifesto for service and product design
 link : https://www.designmanifesto.org/
 author: Niklaus Gerber

--- a/_examples/design-principles-for-bing.md
+++ b/_examples/design-principles-for-bing.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Design Principles for Bing
 author: Microsoft
 overview: |

--- a/_examples/design-principles-for-reducing-cognitive-load.md
+++ b/_examples/design-principles-for-reducing-cognitive-load.md
@@ -1,7 +1,6 @@
 ---
-layout: example
 title: Design principles for reducing cognitive load
-author: Jon Yablonski 
+author: Jon Yablonski
 overview: |
   Every time you visit a website, a process of learning is initiated in the brain. Whether it’s the navigation, layout, or that auto-rotating image slider on the homepage, your brain has to learn how to use the site while keeping track of the reason you came there in the first place. The mental effort required during this time is called cognitive load. Now the catch: the working memory in which this information is processed and stored is limited. Your brain begins to slow down or even abandon the task at hand when it receives more information than it can handle. Although cognitive load isn’t entirely avoidable, designers must strive to manage and accommodate these limits.
 link: https://jonyablonski.com/2015/design-principles-for-reducing-cognitive-load/

--- a/_examples/design-principles-for-windows-store-apps.md
+++ b/_examples/design-principles-for-windows-store-apps.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Design Principles for Windows Store apps
 author: Microsoft
 overview: |

--- a/_examples/designing-for-virtual-reality.md
+++ b/_examples/designing-for-virtual-reality.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Designing for Virtual Reality
 author: Google
 overview: |

--- a/_examples/designing-for-vision-impaired-people.md
+++ b/_examples/designing-for-vision-impaired-people.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Designing for vision impaired people
 author: Wayfindr
 overview: |

--- a/_examples/digital-product-design-principles.md
+++ b/_examples/digital-product-design-principles.md
@@ -1,45 +1,44 @@
 ---
-layout: example
 title: Digital Product Design Principles
 author: Degreed
 overview:
 link: https://dev.degreed.com/digital-product-design-principles-8bc9eb6c080c
 principles:
 - principle: Define the problem first
-  summary: | 
+  summary: |
     Digital design always solves a problem, otherwise it would be pixel art. Understanding the problem thoroughly is essential to design successful solutions. When discussing the product and design internally, always define the problem first before proposing solutions. Thoroughly research the problem before coming up with suitable solutions.
 - principle: Create more value by creating less
-  summary: | 
+  summary: |
     Simplicity is the key to great user experiences. Create fewer features, but make them great instead of just good. Show fewer elements, use simplistic styling to reduce cognitive load. Dare to say ‘No’ to prevent the core functionalities from being lost in the noise.
 - principle: Design performs
-  summary: | 
+  summary: |
     Good design helps the company achieve its business goals. A design is successful when conversion and engagement are getting measurably better. Insights into product performance is key, they should be easily accessible for everyone in the company to make everyone understand which problems are worth to be solved.
 - principle: Strive for consistency
-  summary: | 
+  summary: |
     Be consistent with layouts, design elements, typography and interaction to reduce the cognitive load for the user. Use the style guide as a box of legos where you can take the pre-defined building blocks to create consistent user experiences. We are not designing screens or features, we are designing a platform agnostic service with a consistent user experience.
 - principle: Focus the user on one primary action at a time
-  summary: | 
+  summary: |
     Guide the user by focusing screens, views or actions on one primary task. Be ruthless with the prioritization, make the choices stupidly simple. Limit distraction. All elements and styling that are not helping the user focus on the primary task can be considered as visual clutter and a huge distraction for the user. Be aware that everything in the interface has to be processed by the user’s brain, the less there is to process the lower the cognitive load is.
 - principle: Minimize user input
-  summary: | 
+  summary: |
     User input takes a lot of effort and time. Always strive for the least amount of user input to reach a goal. Every input that is required from the user increases the friction that the user experiences and increases the chance on giving up.
 - principle: Use your user’s language
-  summary: | 
+  summary: |
     Words can both clarify and confuse users. Choose the language your users are using. Choose clarity and be concise. Descriptive and helpful is the primary aim, adding personality secondary. Don’t sound like a system, we are all humans.
 - principle: Make decisions for the user
-  summary: | 
+  summary: |
     Don’t be afraid to make decisions for the user. Offering less choice and options will give the user a more confident feeling, because there is less to worry about. Be aware of the paradox of choice; offering a lot of choice will make the user feel overwhelmed because he/she needs to asses each and every option if it meets his/her goal.
 - principle: Design with strong visual hierarchy
-  summary: | 
+  summary: |
     There are many ways to create visual hierarchy in a design, position, size, color, space. Determine a strict visual hierarchy in every design. Don’t let elements, actions or features compete for attention.
 - principle: Align elements
-  summary: | 
+  summary: |
     The easiest way to accomplish visual balance is to align elements and structure designs with a clear grid. It guides us in the right direction when placing elements and determine dimensions, and it makes it easier for the user to process the interface.
 - principle: Don’t go for ‘WOW’, go for ‘of course’
-  summary: | 
+  summary: |
     Never chase the ‘wow-effect’. Product design succeeds when it solves the problem or need of our users in the best possible way. Design the product effective & delightful. The reaction we are after from our users is “Of course, that is obvious”.
 - principle: Design for change
-  summary: | 
+  summary: |
     No design is ever finished or done. Don’t be afraid of throwing away work, features or designs, good design is always evolving and grows with the business. Design with change in mind will allow us to quickly adapt to new learnings and insights. Every feature or functionality that is introduced needs time to improve. Once something is launched, evaluating performance and iteration should be the focus.
 
 ---

--- a/_examples/digital-services-playbook.md
+++ b/_examples/digital-services-playbook.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Digital Services Playbook
 author: U.S. Digital Services
 overview: |

--- a/_examples/domain-s-design-principles.md
+++ b/_examples/domain-s-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Domain's Design Principles
 author: Domain
 overview:

--- a/_examples/don-norman-s-principles-of-design.md
+++ b/_examples/don-norman-s-principles-of-design.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: Don Normans Principles of Design
 author: Don Norman
 overview: |
-    
+
 link: https://www.amazon.com/Design-Everyday-Things-Donald-Norman/dp/0465067107
 principles:
 - principle: Visibility

--- a/_examples/drupal-7-user-experience-project.md
+++ b/_examples/drupal-7-user-experience-project.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Drupal 7 User Experience Project
 author: Drupal
 overview: |

--- a/_examples/ebay-design-principles.md
+++ b/_examples/ebay-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Ebay Design Principles
 author: Ebay
 overview: |

--- a/_examples/eight-principles-of-information-architecture.md
+++ b/_examples/eight-principles-of-information-architecture.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Eight Principles of Information Architecture
 author: Dan Brown
 overview: |

--- a/_examples/eight-principles-of-natural-user-interfaces.md
+++ b/_examples/eight-principles-of-natural-user-interfaces.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Eight Principles of Natural User Interfaces
 author: Rachel Hinman
 overview:

--- a/_examples/elegant-efficient-and-sophisticated.md
+++ b/_examples/elegant-efficient-and-sophisticated.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Elegant, efficient and sophisticated
 author: Jeff Gothelf
 overview:

--- a/_examples/etsy-design-principles.md
+++ b/_examples/etsy-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Etsy Design Principles
 author: Etsy Design
 overview: |

--- a/_examples/facebook-design-principles.md
+++ b/_examples/facebook-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Facebook Design Principles
 author: Facebook
 overview: |
@@ -28,7 +27,7 @@ principles:
 
 - principle: Useful
   summary: |
-    Our product is more utility than entertainment, meant for repeated daily use, providing value efficiently. This is why our core interactions, the ones users engage daily, are streamlined, purged of unnecessary clicks and wasted space. 
+    Our product is more utility than entertainment, meant for repeated daily use, providing value efficiently. This is why our core interactions, the ones users engage daily, are streamlined, purged of unnecessary clicks and wasted space.
 
 - principle: Fast
   summary: |

--- a/_examples/firefox-design-values.md
+++ b/_examples/firefox-design-values.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Firefox Design Values
 author: Firefox
 overview:

--- a/_examples/first-principles-of-interaction-design.md
+++ b/_examples/first-principles-of-interaction-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: First Principles of Interaction Design
 author: Bruce Tognazzini
 overview: |

--- a/_examples/front-end-principles-for-designers.md
+++ b/_examples/front-end-principles-for-designers.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Front-End Principles for Designers
 author: Jon Yablonski
 overview: |

--- a/_examples/gebruiker-centraal.md
+++ b/_examples/gebruiker-centraal.md
@@ -1,5 +1,4 @@
----
-layout: example #ignore layout! :)
+--- #ignore layout! :)
 title: |
     User Central (Dutch: Gebruiker Centraal)
 author: Actieteam Gebruiker Centraal

--- a/_examples/google-calendars-design-principles.md
+++ b/_examples/google-calendars-design-principles.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: Google Calendar's design principles
 author: Google
 overview:
-link: 
+link:
 principles:
 - principle: Fast, visually appealing, and joyous to use
 - principle: Drop-dead simple to get information into the calendar

--- a/_examples/google-glass-principles.md
+++ b/_examples/google-glass-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Google Glass Principles
 author: Google
 overview: Glass is fundamentally different than existing mobile platforms in both design and use. Follow these principles when building Glassware to give users the best experience.

--- a/_examples/gov-uk-design-principles.md
+++ b/_examples/gov-uk-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Government Design Principles
 author: Government Digital Service
 overview: The UK government's design principles.

--- a/_examples/holstee-s-design-principles.md
+++ b/_examples/holstee-s-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Holstee's Design Principles
 author: Holstee
 overview: Glass is fundamentally different than existing mobile platforms in both design and use. Follow these principles when building Glassware to give users the best experience.

--- a/_examples/htc-hero.md
+++ b/_examples/htc-hero.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: HTC Hero
 author: HTC
 overview:

--- a/_examples/html-design-principles.md
+++ b/_examples/html-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: HTML Design Principles
 author: W3C
 overview: |

--- a/_examples/ibm-6-ux-guidelines.md
+++ b/_examples/ibm-6-ux-guidelines.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: IBM 6 UX Guidelines
 author: IBM Design
 overview: |
-    
+
 link:
 principles:
 - principle: Discover, Try and Buy

--- a/_examples/ibm-design-principles.md
+++ b/_examples/ibm-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: IBM Design Principles
 author: IBM Design
 overview:

--- a/_examples/inclusive-design-principles.md
+++ b/_examples/inclusive-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Inclusive Design Principles
 author: The Paciello Group
 overview: |

--- a/_examples/introduction-to-understanding-wcag-20.md
+++ b/_examples/introduction-to-understanding-wcag-20.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Introduction to Understanding WCAG 2.0
 author: W3C
 overview: |

--- a/_examples/intuits-design-principles.md
+++ b/_examples/intuits-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Intuit's Design Principles
 author: Intuit
 overview: |

--- a/_examples/ios-11-design-principles.md
+++ b/_examples/ios-11-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: iOS 11 Design Principles
 author: Apple
 overview:

--- a/_examples/ios-7-design-principles.md
+++ b/_examples/ios-7-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: iOS 7 Design Principles
 author: Apple
 overview:

--- a/_examples/ios-user-experience-guidelines.md
+++ b/_examples/ios-user-experience-guidelines.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: iOS User Experience Guidelines
 author: Apple
 overview:

--- a/_examples/jda-next-design-principles.md
+++ b/_examples/jda-next-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: JDA NEXT Design Principles
 author: JDA Labs
 overview:

--- a/_examples/laws-of-simplicity.md
+++ b/_examples/laws-of-simplicity.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Laws of Simplicity
 author: John Maeda
 overview: Glass is fundamentally different than existing mobile platforms in both design and use. Follow these principles when building Glassware to give users the best experience.

--- a/_examples/lullabot-s-design-principles.md
+++ b/_examples/lullabot-s-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Lullabots Design Principles
 author: Lullabot
 overview:

--- a/_examples/lyft-design-principles.md
+++ b/_examples/lyft-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Lyft Design Principles
 author: Lyft
 overview: Design principles act as a reusable standard for designers to measure their work. They replace subjective ideals with a shared understanding of what design must do for users. Just as guardrails keep you safe and on the road, design principles keep teams on the path to achieving their vision.

--- a/_examples/manifesto-for-the-experience-of-things.md
+++ b/_examples/manifesto-for-the-experience-of-things.md
@@ -1,11 +1,10 @@
 ---
-layout: example
 title: Manifesto for the Experience of Things
 author: Dan Frost
 overview: |
-    The Internet of Things is the convergence of many technologies. Technologies change our lives when the experience of them fits.  
-    This Manifesto learns from the best physical and digital product design to inform good design in the coming generation of connected products.  
-    While this is informed by the many IoT standards and platforms, this is not a technical document. It is a description of the experience - how the technology will fit into our lives. This is, we believe, how the IoT ecosystem of technologies should be experienced.  
+    The Internet of Things is the convergence of many technologies. Technologies change our lives when the experience of them fits.
+    This Manifesto learns from the best physical and digital product design to inform good design in the coming generation of connected products.
+    While this is informed by the many IoT standards and platforms, this is not a technical document. It is a description of the experience - how the technology will fit into our lives. This is, we believe, how the IoT ecosystem of technologies should be experienced.
 link:
 principles:
 - principle: My. Your. Our. The.
@@ -13,15 +12,15 @@ principles:
     We are now beyond the user. Everything fits into multiple lives. The experience of a one-person or shared device differs from those designed for public or community consumption. Don't unnecessarily carry over the experience decisions from single-user world.
 - principle: Design for scale
   summary: |
-    Scale for users and things. Design for the scale of users, their data and their devices. Each element introduces network effects which put pressure on the others. Do not let the users pick up the slack for your lack of thinking at scale.  
+    Scale for users and things. Design for the scale of users, their data and their devices. Each element introduces network effects which put pressure on the others. Do not let the users pick up the slack for your lack of thinking at scale.
 - principle: Be Obvious
   summary: |
-    The experience should appear to be obvious and inevitable. Go beyond conventions of the underlying technology to make the experience feel like the only way it could have been.  
+    The experience should appear to be obvious and inevitable. Go beyond conventions of the underlying technology to make the experience feel like the only way it could have been.
 - principle: Imbue ownership
   summary: |
-    The feeling of ownership brings trust and the thing becomes part of life. Give reason for this with reliability, clear privacy and control.  
-    Long term ownership of a product differs from transient ownership. Design experience for the right type of ownership.  
+    The feeling of ownership brings trust and the thing becomes part of life. Give reason for this with reliability, clear privacy and control.
+    Long term ownership of a product differs from transient ownership. Design experience for the right type of ownership.
 - principle: Build it to last
   summary: |
-    Renewal rates differ. Some things will be experienced many years after the protocol or platform has expired. Battery life sees devices continue running for years. Good experience looks beyond today's platforms. How will it adapt to new protocols and platforms?  
+    Renewal rates differ. Some things will be experienced many years after the protocol or platform has expired. Battery life sees devices continue running for years. Good experience looks beyond today's platforms. How will it adapt to new protocols and platforms?
 ---

--- a/_examples/manifesto-rules-for-standards-makers.md
+++ b/_examples/manifesto-rules-for-standards-makers.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: "Manifesto: Rules for standards-makers"
 author: Dave Winer
 overview: |

--- a/_examples/mapbox-design-principles.md
+++ b/_examples/mapbox-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: MapBox Design Principles
 author: Mapbox
 overview:
@@ -11,6 +10,6 @@ principles:
   summary: Take advantage of animation and conditional visibility to guide users between steps and to add rhythm and momentum to interactions.
 - principle: Interactions should be delightful and surprising.
   summary: Design these interactions so that they’re enjoyable to perform again and again. Minimize the effort required to complete tasks, enable users to recover from mistakes, and ensure that they receive feedback after taking any action.
-- principle: Focus the user on one primary action at a time. 
+- principle: Focus the user on one primary action at a time.
   summary: Avoid sidebars, widgets, and multi-column layouts. Rather than confronting the user with a multitude of possibilities, use visual hierarchy to help users make meaningful decisions and allow actions to unfold across multiple steps. At the same time, be sure to make it easy for the user to move efficiently between primary actions in case they need to change gears.
 ---

--- a/_examples/material-design.md
+++ b/_examples/material-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Material Design
 author: Google
 overview: |

--- a/_examples/mdn-open-web-apps-principles.md
+++ b/_examples/mdn-open-web-apps-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: MDN Open Web Apps principles
 author: Mozilla Developer Network
 overview: |

--- a/_examples/medium-s-design-principles.md
+++ b/_examples/medium-s-design-principles.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: Early Design Principles at Medium
 author: Medium
 overview: |
-    When medium was small the team wrote down some initial principles. They created a framework that listed two positive thought-provoking words in opposition. 
+    When medium was small the team wrote down some initial principles. They created a framework that listed two positive thought-provoking words in opposition.
 link: https://medium.com/@dustin/thanks-for-writing-the-article-julie-8362fd235ae0
 principles:
 - principle: Direction over Choice

--- a/_examples/mercedes-benz.md
+++ b/_examples/mercedes-benz.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Mercedes-Benz Design Philosophy
 author: Mercedes-Benz
 overview: |

--- a/_examples/microformats-princples.md
+++ b/_examples/microformats-princples.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Microformats Principles
 author: microformats.org
 overview: |

--- a/_examples/microsoft-design-principles.md
+++ b/_examples/microsoft-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Microsoft Design Principles
 author: Microsoft
 overview: |

--- a/_examples/moo-com-design-principles.md
+++ b/_examples/moo-com-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Moo.com UX rules
 author: Richard Pope
 overview: |

--- a/_examples/muji-philosophy.md
+++ b/_examples/muji-philosophy.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: MUJI Philosophy
 author: MUJI
 overview: |

--- a/_examples/occs-design-principles.md
+++ b/_examples/occs-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: OCC’s design principles
 author: Niklaus Gerber
 overview: |

--- a/_examples/opower-design-principles.md
+++ b/_examples/opower-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Opower - Design Principles
 author: Opower
 overview:

--- a/_examples/paypal-design-principles.md
+++ b/_examples/paypal-design-principles.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: Paypal Design Principles
 author: Paypal
 overview:
-link: 
+link:
 principles:
  - principle: We Craft
  - principle: We Simplify

--- a/_examples/principles-and-patterns-for-rich-interaction.md
+++ b/_examples/principles-and-patterns-for-rich-interaction.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles and Patterns for Rich Interaction
 author: Theresa Neil & Bill Scott
 overview: |
@@ -7,27 +6,27 @@ overview: |
 link: http://designingwebinterfaces.com/explore
 principles:
 - principle: Make it Direct
-  summary: | 
+  summary: |
     As Alan Cooper states: "Where there is output, let there be input." This is the principle of direct manipulation. For example, instead of going to a separate page to edit content it can be done inline, directly in the context of the page.
 
 - principle: Keep It Lightweight
-  summary: | 
+  summary: |
     It's about keeping a light footprint. When the user interacts with the application it should be in a way that causes the least amount of physical and mental effort. A primary way to create a light footprint is through the use of Contextual Tools.
 
 - principle: Stay on the Page
-  summary: | 
+  summary: |
     The page refresh is generally disruptive to the user's mental flow. The default on the web is to go from page-to-page for every action. Now that we are no longer bound by those technical limitations, we can decide when to keep the user on the page and in the flow.
 
 - principle: Provide an Invitation
-  summary: | 
+  summary: |
     Discoverability is one of the primary challenges for rich interaction on the Web. A feature is useless if users don't discover it. A key way to improve discoverability is to provide invitations. Invitations cue the user to the next level of interaction.
 
 - principle: Use Transitions
-  summary: | 
+  summary: |
     Animations, cinematic effects, and various other types of visual transitions can be powerful techniques to enhance engagement and communication.
 
 - principle: React Immediately
-  summary: | 
+  summary: |
     A responsive interface is an intelligent interface. This principle explores how to make a rich experience by using lively responses.
 
 ---

--- a/_examples/principles-for-21st-century-government.md
+++ b/_examples/principles-for-21st-century-government.md
@@ -1,10 +1,9 @@
 ---
-layout: example
 title: Principles for 21st Century Government
 author: Code for America
 overview: |
 
-link: 
+link:
 principles:
 - principle: Design for people's needs
 - principle: Make it easy for everyone to participate

--- a/_examples/principles-for-accessibility.md
+++ b/_examples/principles-for-accessibility.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles for Accessibility
 author: Sarah Horton & Whitney Quesenbery
 overview: |

--- a/_examples/principles-for-considerate-products.md
+++ b/_examples/principles-for-considerate-products.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles for Considerate Products
 author: Alan Cooper
 overview: |

--- a/_examples/principles-for-designing-systems-for-expert-users.md
+++ b/_examples/principles-for-designing-systems-for-expert-users.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles for Designing Systems for Expert Users
 author: Natalia Rozycka
 overview: |

--- a/_examples/principles-for-independent-archives.md
+++ b/_examples/principles-for-independent-archives.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles for Independent Archives
 author: Luke Bacon
 overview: |

--- a/_examples/principles-for-prototyping.md
+++ b/_examples/principles-for-prototyping.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles for Prototyping
 author: Todd Zaki Warfel
 overview:

--- a/_examples/principles-of-bot-design.md
+++ b/_examples/principles-of-bot-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of Bot Design
 author: Intercom
 overview:

--- a/_examples/principles-of-calm-technology.md
+++ b/_examples/principles-of-calm-technology.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of Calm Technology
 author: Amber Case
 overview: |

--- a/_examples/principles-of-design.md
+++ b/_examples/principles-of-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of Design
 author: Tim Berners Lee
 link: https://www.w3.org/DesignIssues/Principles.html

--- a/_examples/principles-of-ethical-web-development.md
+++ b/_examples/principles-of-ethical-web-development.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of Ethical Web Development
 author: Adam Scott
 overview: |

--- a/_examples/principles-of-no-ui.md
+++ b/_examples/principles-of-no-ui.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of No UI
 author: Golden Krishna
 overview: |

--- a/_examples/principles-of-pervasive-retail-application-design.md
+++ b/_examples/principles-of-pervasive-retail-application-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of pervasive retail application design
 author: Jonathan Morgan
 overview: The findings presented on this site identify fundamental principles for designing applications for computationally-enhanced retail environments. These principles are distilled from over two hundred research studies and papers on pervasive technology, human-computer interaction, ubiquitous computing, retail strategy, inclusive design, and related fields.

--- a/_examples/principles-of-product-and-service-design.md
+++ b/_examples/principles-of-product-and-service-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of product and service design
 author: Niklaus Gerber
 overview: A simple but essential core set of rules to guide us towards better solutions.

--- a/_examples/principles-of-user-interface-design.md
+++ b/_examples/principles-of-user-interface-design.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: Principles of User Interface Design
 overview: |
-  "To design is much more than simply to assemble, to order, or even to edit; it is to add value and meaning, to illuminate, to simplify, to clarify, to modify, to dignify, to dramatize, to persuade, and perhaps even to amuse." 
-  -Paul Rand 
+  "To design is much more than simply to assemble, to order, or even to edit; it is to add value and meaning, to illuminate, to simplify, to clarify, to modify, to dignify, to dramatize, to persuade, and perhaps even to amuse."
+  -Paul Rand
 author: Joshua Porter
 link: http://bokardo.com/principles-of-user-interface-design/
 featured: true
@@ -25,10 +24,10 @@ principles:
     The best interface is none at all, when we are able to directly manipulate the physical objects in our world. Since this is not always possible, and objects are increasingly informational, we create interfaces to help us interact with them. It is easy to add more layers than necessary to an interface, creating overly-wrought buttons, chrome, graphics, options, preferences, windows, attachments, and other cruft so that we end up manipulating UI elements instead of what's important. Instead, strive for that original goal of direct manipulation…design an interface with as little a footprint as possible, recognizing as much as possible natural human gestures. Ideally, the interface is so slight that the user has a feeling of direct manipulation with the object of their focus.
 - principle: One primary action per screen
   summary: |
-    Every screen we design should support a single action of real value to the person using it. This makes it easier to learn, easier to use, and easier to add to or build on when necessary. Screens that support two or more primary actions become confusing quickly. Like a written article should have a single, strong thesis, every screen we design should support a single, strong action that is its raison d'etre. 
+    Every screen we design should support a single action of real value to the person using it. This makes it easier to learn, easier to use, and easier to add to or build on when necessary. Screens that support two or more primary actions become confusing quickly. Like a written article should have a single, strong thesis, every screen we design should support a single, strong action that is its raison d'etre.
 - principle: Keep secondary actions secondary
   summary: |
-    Screens with a single primary action can have multiple secondary actions but they need to be kept secondary! The reason why your article exists isn't so that people can share it on Twitter…it exists for people to read and understand it. Keep secondary actions secondary by making them lighter weight visually or shown after the primary action has been achieved. 
+    Screens with a single primary action can have multiple secondary actions but they need to be kept secondary! The reason why your article exists isn't so that people can share it on Twitter…it exists for people to read and understand it. Keep secondary actions secondary by making them lighter weight visually or shown after the primary action has been achieved.
 - principle: Provide a natural next step
   summary: |
     Very few interactions are meant to be the last, so thoughtfully design a next step for each interaction a person has with your interface. Anticipate what the next interaction should be and design to support it. Just as we like in human conversation, provide an opening for further interaction. Don't leave a person hanging because they've done what you want them to do…give them a natural next step that helps them further achieve their goals.
@@ -58,14 +57,14 @@ principles:
     The first time experience with an interface is crucial, yet often overlooked by designers. In order to best help our users get up to speed with our designs, it is best to design for the zero state, the state in which nothing has yet occurred. This state shouldn't be a blank canvas…it should provide direction and guidance for getting up to speed. Much of the friction of interaction is in that initial context…once people understand the rules they have a much higher likelihood of success.
 - principle: Existing problems are most valuable
   summary: |
-    People seek out solutions to problems they already have, not potential problems or problems of the future. Therefore, resist creating interfaces for hypothetical problems, observe existing behavior and design to solve existing problems. This isn't as exciting as blue sky wondering but can be much more rewarding as people will actually use your interface. 
+    People seek out solutions to problems they already have, not potential problems or problems of the future. Therefore, resist creating interfaces for hypothetical problems, observe existing behavior and design to solve existing problems. This isn't as exciting as blue sky wondering but can be much more rewarding as people will actually use your interface.
 - principle: Great design is invisible
   summary: |
     A curious property of great design is that it usually goes unnoticed by the people who use it. One reason for this is that if the design is successful the user can focus on their own goals and not the interface…when they complete their goal they are satisfied and do not need to reflect on the situation. As a designer this can be tough…as we receive less adulation when our designs are good. But great designers are content with a well-used design…and know that happy users are often silent.
 - principle: Build on other design disciplines
   summary: |
     Visual and graphic design, typography, copywriting, information architecture and visualization…all of these disciplines are part of interface design. They can be touched upon or specialized in. Do not get into turf wars or look down on other disciplines: grab from them the aspects that help you do your work and push on. Pull in insights from seemingly unrelated disciplines as well…what can we learn from publishing, writing code, bookbinding, skateboarding, firefighting, karate?
-- principle: Interfaces exist to be used   
+- principle: Interfaces exist to be used
   summary: |
     As in most design disciplines, interface design is successful when people are using what you've designed. Like a beautiful chair that is uncomfortable to sit in, design has failed when people choose not to use it. Therefore, interface design can be as much about creating an environment for use as it is creating an artifact worth using. It is not enough for an interface to satisfy the ego of its designer: it must be used!
 ---

--- a/_examples/principles-of-web-development.md
+++ b/_examples/principles-of-web-development.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Principles of Web Development
 author: Jens Meiert
 overview:

--- a/_examples/principles_of_design_with_watson.md
+++ b/_examples/principles_of_design_with_watson.md
@@ -1,5 +1,4 @@
----
-layout: example #ignore layout! :)
+--- #ignore layout! :)
 title: Principles of Design with Watson
 author: Rob Harrigan
 overview: Basic tenets that can be applied when working with IBM Watson — or any AI system and how to think through using them.
@@ -20,5 +19,5 @@ principles:
     Visualizations within the experience should address misconceptions, add to the end user outcome, and make the data easier to comprehend — visualizations are never the deliverable. The deliverable is an insight within it — but never a visualization alone. Watson is amazing when it is finding patterns and teasing those out in massive amounts of data — what we have to keep in mind is what our users need to take away — we are leading them to the needle in the noisy data haystack.
 - principle: Always in service of people never in lieu of them.
   summary: |
-    The user and Watson are partners working towards mutual goals through an experience. We have to solve the user’s need which is central to success but we also have to enable human and computer cooperation — not only interaction. Building empathy, trust, and cooperation with our users is the goal. We should be focused on removing limitations and addressing pain points. Watson never makes a decision for a person — it finds, augment and educates.  
+    The user and Watson are partners working towards mutual goals through an experience. We have to solve the user’s need which is central to success but we also have to enable human and computer cooperation — not only interaction. Building empathy, trust, and cooperation with our users is the goal. We should be focused on removing limitations and addressing pain points. Watson never makes a decision for a person — it finds, augment and educates.
 ---

--- a/_examples/quartz-design-principles.md
+++ b/_examples/quartz-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Quartz Design Principles
 author: Quartz
 overview:

--- a/_examples/reactjs-design-principles.md
+++ b/_examples/reactjs-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: React Design Principles
 author: React
 overview: |

--- a/_examples/responsive-principles.md
+++ b/_examples/responsive-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Responsive Principles
 author: Paul Robert Lloyd
 overview: |

--- a/_examples/salesforce-lightning-design-principles.md
+++ b/_examples/salesforce-lightning-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Salesforce Lightning Design Principles
 author: Salesforce
 overview: |

--- a/_examples/sap-fiori-design-principles.md
+++ b/_examples/sap-fiori-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: SAP Fiori Design Principles
 author: SAP
 overview: |

--- a/_examples/service-design-principles.md
+++ b/_examples/service-design-principles.md
@@ -1,9 +1,8 @@
 ---
-layout: example
 title: Service Design Principles
 author: Tim Manning
 overview: |
-    
+
 link: http://design4services.com/methods/enterprise-architecture/design-principles/
 principles:
 - principle: General Principles

--- a/_examples/shneidermans-eight-golden-rules-of-interface-design.md
+++ b/_examples/shneidermans-eight-golden-rules-of-interface-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: |
   Shneiderman's "Eight Golden Rules of Interface Design"
 author: Ben Shneiderman

--- a/_examples/six-characteristics-of-good-apis.md
+++ b/_examples/six-characteristics-of-good-apis.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Six Characteristics of Good APIs
 author: Google
 overview:

--- a/_examples/six-universal-ibm-experiences.md
+++ b/_examples/six-universal-ibm-experiences.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Six Universal IBM experiences
 author: IBM Design
 overview: |

--- a/_examples/ten-principles-of-good-design.md
+++ b/_examples/ten-principles-of-good-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Ten Principles for Good Design
 author: Dieter Rams
 overview: |

--- a/_examples/ten-principles-of-simplicity.md
+++ b/_examples/ten-principles-of-simplicity.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Ten Principles of Simplicity
 author: Jay Selway
 overview: |

--- a/_examples/ten-principles-that-contribute-to-a-googley-experience.md
+++ b/_examples/ten-principles-that-contribute-to-a-googley-experience.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Ten Principles that Contribute to a Googley Experience
 author: Google
 overview:

--- a/_examples/ten-rules-for-startups.md
+++ b/_examples/ten-rules-for-startups.md
@@ -1,8 +1,7 @@
 ---
-layout: example
 title: Ten Rules for Web Startups
 author: Evan Williams
-link: 
+link:
 principles:
 - principle: Be narrow
 - principle: Be different
@@ -14,5 +13,5 @@ principles:
 - principle: Be tiny
 - principle: Be agile
 - principle: Be balanced
-- principle: (bonus!) Be wary     
+- principle: (bonus!) Be wary
 ---

--- a/_examples/ten-things-we-know-to-be-true.md
+++ b/_examples/ten-things-we-know-to-be-true.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Ten Things We Know to be True
 author: Google
 overview:

--- a/_examples/the-10-principles-of-successful-lean-product-teams.md
+++ b/_examples/the-10-principles-of-successful-lean-product-teams.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The 10 Principles of Successful Lean Product Teams
 author: Luxr
 overview:

--- a/_examples/the-10000-year-clock.md
+++ b/_examples/the-10000-year-clock.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Ten Tenets of Chindogu
 author: Danny Hillis
 overview: |

--- a/_examples/the-12-realistic-principles-of-agile-ux.md
+++ b/_examples/the-12-realistic-principles-of-agile-ux.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The 12 Realistic Principles of Agile UX
 author: Guiseppe Getto
 overview:

--- a/_examples/the-arch-way.md
+++ b/_examples/the-arch-way.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Arch Way
 author: Arch Linux
 overview: |

--- a/_examples/the-building-blocks-of-sustainable-web-design.md
+++ b/_examples/the-building-blocks-of-sustainable-web-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Building Blocks of Sustainable Web Design
 author: Mightybytes
 overview: |

--- a/_examples/the-ecology-of-multi-device-design.md
+++ b/_examples/the-ecology-of-multi-device-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Ecology of Multi-Device Design
 author: Punchcut
 overview: |

--- a/_examples/the-edenspiekermann-manifesto.md
+++ b/_examples/the-edenspiekermann-manifesto.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Edenspiekermann Manifesto
 author: Edenspiekermann
 overview:

--- a/_examples/the-four-cs-of-form-design.md
+++ b/_examples/the-four-cs-of-form-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Four C's of Form Design
 author: Jessica Enders
 overview: |

--- a/_examples/the-lean-startup-principles.md
+++ b/_examples/the-lean-startup-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Lean Startup Principles
 author: Eric Ries
 overview: Startup success can be engineered by following the process, which means it can be learned, which means it can be taught.

--- a/_examples/the-meta-principles-for-visual-usability.md
+++ b/_examples/the-meta-principles-for-visual-usability.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Meta Principles for Visual Usability
 author: Tania Schlatter
 overview: Glass is fundamentally different than existing mobile platforms in both design and use. Follow these principles when building Glassware to give users the best experience.

--- a/_examples/the-nine-principles-of-design-implementation.md
+++ b/_examples/the-nine-principles-of-design-implementation.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Nine Principles Of Design Implementation
 author: Tom Greever
 overview: |

--- a/_examples/the-ten-principles-of-inclusive-design.md
+++ b/_examples/the-ten-principles-of-inclusive-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Ten Principles of Interaction Design
 author: Sandi Wassmer
 featured: true

--- a/_examples/the-ten-tenents-of-chindogu.md
+++ b/_examples/the-ten-tenents-of-chindogu.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The Ten Tenets of Chindogu
 author: International Chindogu Society
 overview: |

--- a/_examples/the-ux-axioms.md
+++ b/_examples/the-ux-axioms.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: The UX Axioms
 author: Erik Dahl
 overview: |

--- a/_examples/tivos-revised-design-principles.md
+++ b/_examples/tivos-revised-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Tivo's Revised Design Principles
 author: Tivo
 overview:

--- a/_examples/tizen-design-principles.md
+++ b/_examples/tizen-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Tizen Design Principles
 author: Tizen
 overview:

--- a/_examples/uber-design-principles.md
+++ b/_examples/uber-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Uber Design Principles
 author: Uber Design
 overview: |

--- a/_examples/unix_philosophy.md
+++ b/_examples/unix_philosophy.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: UNIX philosophy
 author: Doug McIlroy
 overview: |
@@ -16,7 +15,7 @@ principles:
 - principle: Build a prototype as soon as possible.
   summary: |
     Design and build software, even operating systems, to be tried early, ideally within weeks. Don't hesitate to throw away the clumsy parts and rebuild them.
-    
+
 - principle: Build software tools.
   summary: |
     Use tools in preference to unskilled help to lighten a programming task, even if you have to detour to build the tools and expect to throw some of them out after you've finished using them.

--- a/_examples/voice-user-interface-principles.md
+++ b/_examples/voice-user-interface-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Voice User Interface Principles
 author: Stephen Gay
 overview:

--- a/_examples/weight-watchers-design-principles.md
+++ b/_examples/weight-watchers-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Weight Watchers Design Principles
 author: Weight Watchers
 overview: |
@@ -7,33 +6,33 @@ overview: |
 link: https://www.wwstyleguide.com/overview-design-principles/
 principles:
 - principle: Personas
-  summary: Design for Weight Watchers members illustrated by product personas 
+  summary: Design for Weight Watchers members illustrated by product personas
 
 - principle: Experience
-  summary: Design for the entire product experience rather than isolated needs 
+  summary: Design for the entire product experience rather than isolated needs
 
 - principle: Context
-  summary: Keep context in mind – where’s the member coming from and where are they going 
+  summary: Keep context in mind – where’s the member coming from and where are they going
 
 - principle: The 80%
-  summary: Optimize the design for the 80% use case - most members most of the time 
+  summary: Optimize the design for the 80% use case - most members most of the time
 
 - principle: Simplicity
-  summary: Design for simplicity while supporting functionality, visual language and brand 
+  summary: Design for simplicity while supporting functionality, visual language and brand
 
 - principle: Patterns
-  summary: Design within the current product patterns when possible 
+  summary: Design within the current product patterns when possible
 
 - principle: Extensibility
-  summary: Create new patterns when existing patterns don’t solve a new problem. New patterns should be consistent and extensible. 
+  summary: Create new patterns when existing patterns don’t solve a new problem. New patterns should be consistent and extensible.
 
 - principle: Platform
-  summary: Patterns should follow the native platform while still serving the brand 
+  summary: Patterns should follow the native platform while still serving the brand
 
 - principle: Hierarchy
-  summary: Clearly define hierarchy and level of detail on each screen - focus on the main objective 
+  summary: Clearly define hierarchy and level of detail on each screen - focus on the main objective
 
 - principle: Empathy
-  summary: Design with member empathy 
+  summary: Design with member empathy
 
 ---

--- a/_examples/what-is-a-good-standard.md
+++ b/_examples/what-is-a-good-standard.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: What is a good standard?
 author: Bert Bos
 overview: |

--- a/_examples/what-the-heck-is-inclusive-design.md
+++ b/_examples/what-the-heck-is-inclusive-design.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: What the Heck Is Inclusive Design?
 author: Heydon Pickering
 overview: |

--- a/_examples/wikihouse-10-design-principles.md
+++ b/_examples/wikihouse-10-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: WikiHouse 10 Design Principles
 author: WikiHouse
 overview: |

--- a/_examples/willem-sandberg.md
+++ b/_examples/willem-sandberg.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Willem Sandberg
 author: Willem Sandberg
 overview:

--- a/_examples/windows-user-experience-design-principles.md
+++ b/_examples/windows-user-experience-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Windows User Experience Design Principles
 author: Microsoft
 overview:

--- a/_examples/zappo-s-design-principles.md
+++ b/_examples/zappo-s-design-principles.md
@@ -1,5 +1,4 @@
 ---
-layout: example
 title: Zappo's Design Principles
 author: Zappo
 overview: |


### PR DESCRIPTION
- Examples now use `example.html` layout by default (defined in `config.yml`), removing the need to include `layout: example` in each Example entry's frontmatter (this can still be overridden by defining a different layout in the frontmatter of each page). 

- Whitespace characters have been removed as they can cause problems with parsing YAML.